### PR TITLE
Fix to the correct property BucketName

### DIFF
--- a/snippets/yaml-snippets.json
+++ b/snippets/yaml-snippets.json
@@ -1215,7 +1215,7 @@
 			"  Type: AWS::S3::Bucket",
 			"  Properties: ",
 			"    AccessControl: ${2:Private | PublicRead | PublicReadWrite | AuthenticatedRead | LogDeliveryWrite | BucketOwnerRead | BucketOwnerFullControl}",
-			"    Bucketname: ${3}",
+			"    BucketName: ${3}",
 			"    CorsConfiguration: ${4}",
 			"    LifecycleConfiguration: ${5}",
 			"    NotificationConfiguration: ${6}",


### PR DESCRIPTION
The s3Bucket property was not written in CamelCase, so deploying a new stack with the s3Bucket snippet runs into a failure.