### PR TITLE
Solves #19

### DIFF
--- a/snippets/yaml-snippets.json
+++ b/snippets/yaml-snippets.json
@@ -1215,7 +1215,7 @@
 			"  Type: AWS::S3::Bucket",
 			"  Properties: ",
 			"    AccessControl: ${2:Private | PublicRead | PublicReadWrite | AuthenticatedRead | LogDeliveryWrite | BucketOwnerRead | BucketOwnerFullControl}",
-			"    Bucketname: ${3}",
+			"    BucketName: ${3}",
 			"    CorsConfiguration: ${4}",
 			"    LifecycleConfiguration: ${5}",
 			"    NotificationConfiguration: ${6}",


### PR DESCRIPTION
`Bucketname` -> `BucketName`.

_BucketName_ property in _AWS::S3::Bucket_ snippet is camel case.