### PR TITLE
updated settings to reduce YAML parse errors/complaints

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ After installation, open your User Settings ```(Ctrl + ,)``` and paste preferenc
         "!Not",
         "!Equals",
         "!Or",
-        "!FindInMap",
+        "!FindInMap sequence",
         "!Base64",
         "!Cidr",
         "!Ref",
@@ -56,8 +56,9 @@ After installation, open your User Settings ```(Ctrl + ,)``` and paste preferenc
         "!GetAZs",
         "!ImportValue",
         "!Select",
+        "!Select sequence",
         "!Split",
-        "!Join"
+        "!Join sequence"
     ],
     // Enable/disable default YAML formatter (requires restart)
     "yaml.format.enable": true,


### PR DESCRIPTION
Adding a couple extra data type specifiers in the `settings.json` example will reduce the number of errors by default in CloudFormation YAML. This addresses #12 and is basically the workaround mentioned in the comments in  redhat-developer/yaml-language-server#77. I was getting the error mentioned in #12 myself, but with these in my User Settings, I no longer get the error. 