### PR TITLE
Fix Internet Gateway YAML snippet

### DIFF
--- a/snippets/yaml-snippets.json
+++ b/snippets/yaml-snippets.json
@@ -432,7 +432,7 @@
 			"${4:AttachGateway}:",
 			"  Type: AWS::EC2::VPCGatewayAttachment",
 			"  Properties:",
-			"    VpcId: ${4:vpc-id}",
+			"    VpcId: ${5:vpc-id}",
 			"    InternetGatewayId: !Ref ${1:igwName}"
 		],
 		"description": "",


### PR DESCRIPTION
## Problem
The `internet-gateway` YAML snippet put the cursor at the `AttachGateway` key and the `VpcId` value at the same time. They should be separate edit points.

## Solution
Increase cursor index by one.