### PR TITLE
fix eip spacing issue

### DIFF
--- a/snippets/yaml-snippets.json
+++ b/snippets/yaml-snippets.json
@@ -257,8 +257,8 @@
 			"${1:eipName}:",
 			"  Type: AWS::EC2::EIP",
 			"  Properties:",
-			"  Domain: vpc",
-			"  InstanceId: ${2:instance-id}"
+			"    Domain: vpc",
+			"    InstanceId: ${2:instance-id}"
 		],
 		"description": "",
 		"scope": "source.cloudformation"


### PR DESCRIPTION
added indentation to properties on eip resource in YAML snippets. This does not occur in JSON snippets